### PR TITLE
Include libfuzzy-dev in Dockerfile

### DIFF
--- a/misp-web/Dockerfile
+++ b/misp-web/Dockerfile
@@ -38,7 +38,7 @@ RUN sed -i "s/memory_limit = 128M/memory_limit = 512M/" /etc/php/7.2/apache2/php
 RUN sed -i "s/upload_max_filesize = 2M/upload_max_filesize = 50M/" /etc/php/7.2/apache2/php.ini
 RUN sed -i "s/post_max_size = 8M/post_max_size = 50M/" /etc/php/7.2/apache2/php.ini
 
-RUN apt-get install -y python-dev python-pip libxml2-dev libxslt1-dev zlib1g-dev python-setuptools
+RUN apt-get install -y python-dev python-pip libxml2-dev libxslt1-dev zlib1g-dev python-setuptools libfuzzy-dev
 RUN apt-get install -y cron logrotate supervisor syslog-ng-core
 RUN apt-get clean
 


### PR DESCRIPTION
libfuzzy-dev is a dependency for PyDeep.
Adding to Dockerfile would eliminate an additional step post install.