### PR TITLE
Additional arg for misp-module and changed user in supervisord.conf

### DIFF
--- a/misp-web/Dockerfile
+++ b/misp-web/Dockerfile
@@ -163,8 +163,8 @@ RUN echo 'startsecs = 0' >> /etc/supervisor/conf.d/supervisord.conf
 RUN echo 'autorestart = false' >> /etc/supervisor/conf.d/supervisord.conf
 RUN echo '' >> /etc/supervisor/conf.d/supervisord.conf
 RUN echo '[program:misp-modules]' >> /etc/supervisor/conf.d/supervisord.conf
-RUN echo 'command=/bin/bash -c "cd /opt/misp-modules/bin && /usr/bin/python3 misp-modules.py"' >> /etc/supervisor/conf.d/supervisord.conf
-RUN echo 'user = root' >> /etc/supervisor/conf.d/supervisord.conf
+RUN echo 'command=/bin/bash -c "misp-modules -s -l 127.0.0.1"' >> /etc/supervisor/conf.d/supervisord.conf
+RUN echo 'user = www-data' >> /etc/supervisor/conf.d/supervisord.conf
 RUN echo 'startsecs = 0' >> /etc/supervisor/conf.d/supervisord.conf
 RUN echo 'autorestart = false' >> /etc/supervisor/conf.d/supervisord.conf
 

--- a/misp-web/Dockerfile
+++ b/misp-web/Dockerfile
@@ -137,7 +137,7 @@ RUN pip3 install --upgrade --ignore-installed urllib3
 RUN pip3 install --upgrade --ignore-installed requests
 RUN pip3 install -I -r REQUIREMENTS
 RUN pip3 install -I .
-RUN echo "sudo -u www-data misp-modules -s &" >>/etc/rc.local
+RUN echo "sudo -u www-data misp-modules -s -l 127.0.0.1 &" >>/etc/rc.local
 
 # Supervisord Setup
 RUN echo '[supervisord]' >> /etc/supervisor/conf.d/supervisord.conf


### PR DESCRIPTION
The misp-modules run command in the current Dockerfile fails due to using default listen address of localhost. This is corrected by specifying loopback instead. Also, there is no longer an ```/opt/misp-modules/bin``` directory and that causes misp-modules to fail on load via supervisor. This is corrected by passing the same command previously stated in ```/etc/rc.local``` and changing the next line below from ```root``` to ```www-data``` to limit perms of the process in ```/etc/supervisor/conf.d/supervisord.conf```.