### PR TITLE
Fix broken web/Dockerfile && web/run.sh

### DIFF
--- a/web/Dockerfile
+++ b/web/Dockerfile
@@ -76,18 +76,12 @@ WORKDIR /var/www/MISP/app
 
 # FIX COMPOSER
 RUN php -r "copy('https://getcomposer.org/installer', 'composer-setup.php');"
-RUN php -r "if (hash_file('sha384', 'composer-setup.php') === '48e3236262b34d30969dca3c37281b3b4bbe3221bda826ac6a9$
+RUN php -r "if (hash_file('sha384', 'composer-setup.php') === '48e3236262b34d30969dca3c37281b3b4bbe3221bda826ac6a9a62d6444cdb0dcd0615698a5cbe587c3f0fe57a54d8f5') { echo 'Installer verified'; } else { echo 'Installer corrupt'; unlink('composer-setup.php'); } echo PHP_EOL;"
 RUN php composer-setup.php
 RUN php -r "unlink('composer-setup.php');"
 # END FIX
 
 RUN php composer.phar config vendor-dir Vendor
-
-RUN php -r "copy('https://getcomposer.org/installer', 'composer-setup.php');"
-RUN php -r "if (hash_file('sha384', 'composer-setup.php') === '48e3236262b34d30969dca3c37281b3b4bbe3221bda826ac6a9a62d6444cdb0dcd0615698a5cbe587c3f0fe57a54d8f5') { echo 'Installer verified'; } else { echo 'Installer corrupt'; unlink('composer-setup.php'); } echo PHP_EOL;"
-RUN php composer-setup.php
-RUN php -r "unlink('composer-setup.php');"
-
 RUN php composer.phar install --ignore-platform-reqs
 USER root
 RUN phpenmod redis

--- a/web/run.sh
+++ b/web/run.sh
@@ -122,7 +122,7 @@ Passphrase: $MISP_ADMIN_PASSPHRASE
 GPGEOF
                 sudo -u www-data gpg --homedir /var/www/MISP/.gnupg --gen-key --batch /tmp/gpg.tmp >>/tmp/install.log
                 rm -f /tmp/gpg.tmp
-		sudo -u www-data gpg --homedir /var/www/MISP/.gnupg --export --armor $MISP_ADMIN_EMAIL > /var/www/MISP/app/webroot/gpg.asc"
+		sudo -u www-data gpg --homedir /var/www/MISP/.gnupg --export --armor $MISP_ADMIN_EMAIL > /var/www/MISP/app/webroot/gpg.asc
         fi
 
         # Display tips


### PR DESCRIPTION
- "# FIX COMPOSER" entries have (probably) been copied-pasted twice from a terminal, with one truncated line at (hash_file('sha384', 'composer-setup.php')) that breaks the script.
- An unmatched double quote in `run.sh` causes (unexpected EOF while looking for matching `"')