### PR TITLE
update dockerfile to contain mysql PDO extension

### DIFF
--- a/web/Dockerfile
+++ b/web/Dockerfile
@@ -31,6 +31,8 @@ RUN a2dissite 000-default
 # PHP 7.2
 RUN apt-get install -y libapache2-mod-php php7.2 php7.2-cli php-crypt-gpg php7.2-dev php7.2-json php7.2-mysql php7.2-opcache php7.2-readline php7.2-redis php7.2-xml
 RUN apt-get install -y php-pear pkg-config libbson-1.0 libmongoc-1.0-0 php-xml php-dev
+# install MySQL PDO extension
+RUN apt-get install -y php-mysql
 
 # Fix php.ini with recommended settings
 RUN sed -i "s/max_execution_time = 30/max_execution_time = 300/" /etc/php/7.2/apache2/php.ini


### PR DESCRIPTION
Adding

`apt-get install -u php-mysql`

otherwise on startup you'll get an internal 500 error, with /tmp/logs showing:

```
2019-07-08 11:21:02 Error: [MissingConnectionException] Database connection "Mysql" is missing, or could not be created.
Exception Attributes: array (
  'class' => 'Mysql',
  'message' => 'Selected driver is not enabled',
  'enabled' => false,
)
```