### PR TITLE
Fixing issues when building behind a proxy

### DIFF
--- a/web/Dockerfile
+++ b/web/Dockerfile
@@ -77,7 +77,7 @@ RUN git submodule update
 WORKDIR /var/www/MISP/app
 
 # FIX COMPOSER
-RUN php -r "copy('https://getcomposer.org/installer', 'composer-setup.php');"
+RUN curl --fail --location -o composer-setup.php https://getcomposer.org/installer
 RUN php -r "if (hash_file('sha384', 'composer-setup.php') === '48e3236262b34d30969dca3c37281b3b4bbe3221bda826ac6a9a62d6444cdb0dcd0615698a5cbe587c3f0fe57a54d8f5') { echo 'Installer verified'; } else { echo 'Installer corrupt'; unlink('composer-setup.php'); } echo PHP_EOL;"
 RUN php composer-setup.php
 RUN php -r "unlink('composer-setup.php');"

--- a/web/Dockerfile
+++ b/web/Dockerfile
@@ -138,7 +138,7 @@ RUN rm -rf taxonomies && git clone https://github.com/MISP/misp-taxonomies.git .
 RUN chown -R www-data:www-data misp-objects misp-galaxy warninglists taxonomies
 
 # Install MISP build requirements
-RUN sudo apt-get -y install libpoppler58 libpoppler-dev libpoppler-cpp-dev
+RUN sudo -E apt-get -y install libpoppler58 libpoppler-dev libpoppler-cpp-dev
 
 # Install MISP Modules
 WORKDIR /opt


### PR DESCRIPTION
Hello there,
in order to build in an environment, which requires a HTTP proxy (i.e. our corporate environment) to download remote resources
`ENV http_proxy=<ProxyURI(+credentials)>`
`ENV https_proxy=<ProxyURI(+credentials)>`
has to be set at the beginning of `web/Dockerfile` (or provided as build args).

Two lines cause problems, if this approach is used:
`RUN php -r "copy('https://getcomposer.org/installer', 'composer-setup.php');"`
This line doesn't seem to respect the environment variables mentioned above and fails to download throwing a warning. The build process fails 2 lines later, when the file is supposed to be executed (not at the download itself, as it seems to still return 0 as exit code. I suggest using curl instead, as there is no apparent reason to invoke PHP for this task (and using curl fixes the problem).
`RUN curl --fail --location -o composer-setup.php https://getcomposer.org/installer`

`RUN sudo -E apt-get -y install libpoppler58 libpoppler-dev libpoppler-cpp-dev`
When using `http_proxy` environment variables, using `sudo` without `-E` causes them to be unavailable in the following command, which results in `apt-get` failing.
I suggest using either the `-E` option or switching to root for this invocation of `apt-get install`.
