### PR TITLE
Update SHA384 of composer-setup.php

### DIFF
--- a/web/Dockerfile
+++ b/web/Dockerfile
@@ -78,7 +78,7 @@ WORKDIR /var/www/MISP/app
 
 # FIX COMPOSER
 RUN php -r "copy('https://getcomposer.org/installer', 'composer-setup.php');"
-RUN php -r "if (hash_file('sha384', 'composer-setup.php') === '48e3236262b34d30969dca3c37281b3b4bbe3221bda826ac6a9a62d6444cdb0dcd0615698a5cbe587c3f0fe57a54d8f5') { echo 'Installer verified'; } else { echo 'Installer corrupt'; unlink('composer-setup.php'); } echo PHP_EOL;"
+RUN php -r "if (hash_file('sha384', 'composer-setup.php') === 'a5c698ffe4b8e849a443b120cd5ba38043260d5c4023dbf93e1558871f1f07f58274fc6f4c93bcfd858c6bd0775cd8d1') { echo 'Installer verified'; } else { echo 'Installer corrupt'; unlink('composer-setup.php'); } echo PHP_EOL;"
 RUN php composer-setup.php
 RUN php -r "unlink('composer-setup.php');"
 # END FIX


### PR DESCRIPTION
Update SHA384 of `composer-setup.php` according to [source](https://getcomposer.org/installer)

```
$ wget "https://getcomposer.org/installer"
--2019-08-05 23:21:02--  https://getcomposer.org/installer
Loaded CA certificate '/etc/ssl/certs/ca-certificates.crt'
Resolving getcomposer.org (getcomposer.org)... xxxxxxxxxx
Connecting to getcomposer.org (getcomposer.org)|xxxxxxxxxx|:443... connected.
HTTP request sent, awaiting response... 200 OK
Length: 275959 (269K) [application/octet-stream]
Saving to: ‘installer’

installer                                                   100%[=========================================================================================================================================>] 269.49K   278KB/s    in 1.0s    

2019-08-05 23:21:05 (278 KB/s) - ‘installer’ saved [275959/275959]

$ sha384sum installer 
a5c698ffe4b8e849a443b120cd5ba38043260d5c4023dbf93e1558871f1f07f58274fc6f4c93bcfd858c6bd0775cd8d1  installer
```