### PR TITLE
changed composer-setup hash to match composer 1.9.0 hash

### DIFF
--- a/web/Dockerfile
+++ b/web/Dockerfile
@@ -78,7 +78,7 @@ WORKDIR /var/www/MISP/app
 
 # FIX COMPOSER
 RUN php -r "copy('https://getcomposer.org/installer', 'composer-setup.php');"
-RUN php -r "if (hash_file('sha384', 'composer-setup.php') === '48e3236262b34d30969dca3c37281b3b4bbe3221bda826ac6a9a62d6444cdb0dcd0615698a5cbe587c3f0fe57a54d8f5') { echo 'Installer verified'; } else { echo 'Installer corrupt'; unlink('composer-setup.php'); } echo PHP_EOL;"
+RUN php -r "if (hash_file('sha384', 'composer-setup.php') === 'a5c698ffe4b8e849a443b120cd5ba38043260d5c4023dbf93e1558871f1f07f58274fc6f4c93bcfd858c6bd0775cd8d1') { echo 'Installer verified'; } else { echo 'Installer corrupt'; unlink('composer-setup.php'); } echo PHP_EOL;"
 RUN php composer-setup.php
 RUN php -r "unlink('composer-setup.php');"
 # END FIX


### PR DESCRIPTION
Composer 1.9.0 was [recently released on 2019-08-02](https://github.com/composer/composer/blob/master/CHANGELOG.md) and the hash check being done by the Dockerfile in the web container was failing as a result of the new binary.  Added new hash as seen [here](https://getcomposer.org/download/)