### PR TITLE
fix lxml build failure in web/Dockerfile

### DIFF
--- a/web/Dockerfile
+++ b/web/Dockerfile
@@ -40,7 +40,7 @@ RUN sed -i "s/memory_limit = 128M/memory_limit = 512M/" /etc/php/7.2/apache2/php
 RUN sed -i "s/upload_max_filesize = 2M/upload_max_filesize = 50M/" /etc/php/7.2/apache2/php.ini
 RUN sed -i "s/post_max_size = 8M/post_max_size = 50M/" /etc/php/7.2/apache2/php.ini
 
-RUN apt-get install -y python-dev python-pip libxml2-dev libxslt1-dev zlib1g-dev python-setuptools libfuzzy-dev
+RUN apt-get install -y python-dev python-pip libxml2-dev libxslt1-dev zlib1g-dev python-setuptools libfuzzy-dev python-lxml python3-lxml
 RUN apt-get install -y cron logrotate supervisor syslog-ng-core
 RUN apt-get clean
 


### PR DESCRIPTION
Fix for the issue #47 :

> Searching for lxml>=2.2.3
> Reading https://pypi.python.org/simple/lxml/
> Best match: lxml 4.4.1
> Downloading https://files.pythonhosted.org/packages/c4/43/3f1e7d742e2a7925be180b6af5e0f67d38de2f37560365ac1a0b9a04c015/lxml-4.4.1.tar.gz#sha256=c81cb40bff373ab7a7446d6bbca0190bccc5be3448b47b51d729e37799bb5692
> Processing lxml-4.4.1.tar.gz
> Writing /tmp/easy_install-9a7Zl7/lxml-4.4.1/setup.cfg
> Running lxml-4.4.1/setup.py -q bdist_egg --dist-dir /tmp/easy_install-9a7Zl7/lxml-4.4.1/egg-dist-tmp-jazmDM
> /usr/lib/python2.7/distutils/dist.py:267: UserWarning: Unknown distribution option: 'python_requires'
> warnings.warn(msg)
> In file included from src/lxml/etree.c:692:0:
> src/lxml/includes/etree_defs.h:14:31: fatal error: libxml/xmlversion.h: No such file or directory
> compilation terminated.
> /tmp/easy_install-9a7Zl7/lxml-4.4.1/temp/xmlXPathInitgop7jj.c:2:1: warning: return type defaults to ‘int’ [-Wimplicit-int]
> main (int argc, char **argv) {
> ^
> Building lxml version 4.4.1.
> Building without Cython.
> Using build configuration of libxslt 1.1.28
> ERROR: /usr/bin/xslt-config: 1: /usr/bin/xslt-config: xml2-config: not found
> 
> ** make sure the development packages of libxml2 and libxslt are installed **
> 
> Compile failed: command 'x86_64-linux-gnu-gcc' failed with exit status 1
> error: Setup script exited with error: command 'x86_64-linux-gnu-gcc' failed with exit status 1
> ERROR: Service 'web' failed to build: The command '/bin/sh -c python setup.py install' returned a non-zero code: 1
> 

Resolved it by adding:
python-lxml python3-lxml to the apt-get installations.