### PR TITLE
PHP-memory limit recommendation changed to 2048

### DIFF
--- a/web/Dockerfile
+++ b/web/Dockerfile
@@ -36,7 +36,7 @@ RUN apt-get install -y php-mysql
 
 # Fix php.ini with recommended settings
 RUN sed -i "s/max_execution_time = 30/max_execution_time = 300/" /etc/php/7.2/apache2/php.ini
-RUN sed -i "s/memory_limit = 128M/memory_limit = 512M/" /etc/php/7.2/apache2/php.ini
+RUN sed -i "s/memory_limit = 128M/memory_limit = 2048M/" /etc/php/7.2/apache2/php.ini
 RUN sed -i "s/upload_max_filesize = 2M/upload_max_filesize = 50M/" /etc/php/7.2/apache2/php.ini
 RUN sed -i "s/post_max_size = 8M/post_max_size = 50M/" /etc/php/7.2/apache2/php.ini
 


### PR DESCRIPTION
Recommended memory limit for MISP was changed from 512M to 2048M in version 2.4.114