### PR TITLE
Update Dockerfile to include latest PHP composer version hash

### DIFF
--- a/web/Dockerfile
+++ b/web/Dockerfile
@@ -81,7 +81,7 @@ WORKDIR /var/www/MISP/app
 
 # FIX COMPOSER
 RUN curl --fail --location -o composer-setup.php https://getcomposer.org/installer
-RUN php -r "if (hash_file('sha384', 'composer-setup.php') === 'a5c698ffe4b8e849a443b120cd5ba38043260d5c4023dbf93e1558871f1f07f58274fc6f4c93bcfd858c6bd0775cd8d1') { echo 'Installer verified'; } else { echo 'Installer corrupt'; unlink('composer-setup.php'); } echo PHP_EOL;"
+RUN php -r "if (hash_file('sha384', 'composer-setup.php') === 'baf1608c33254d00611ac1705c1d9958c817a1a33bce370c0595974b342601bd80b92a3f46067da89e3b06bff421f182') { echo 'Installer verified'; } else { echo 'Installer corrupt'; unlink('composer-setup.php'); } echo PHP_EOL;"
 RUN php composer-setup.php
 RUN php -r "unlink('composer-setup.php');"
 # END FIX


### PR DESCRIPTION
The Dockerfile includes PHP composer installation instructions from getcomposer.org, which includes a hash of the payload to verify installation. On a recent release the hash changed, this
pull request includes the new hash.

You can verify at: https://getcomposer.org/download/
