### PR TITLE
Add a healthcheck endpoint

### DIFF
--- a/web/Dockerfile
+++ b/web/Dockerfile
@@ -98,6 +98,10 @@ RUN echo "postfix postfix/main_mailer_type string Local only" \
 RUN sed -i 's/^\(daemonize\s*\)yes\s*$/\1no/g' /etc/redis/redis.conf
 RUN sed -i 's/^\(bind\s*\)127.0.0.1 ::1\s*$/\1127.0.0.1/g' /etc/redis/redis.conf
 
+# Add a healthcheck endpoint
+COPY healthcheck.patch healthcheck.patch
+RUN patch /var/www/MISP/INSTALL/apache.misp.ubuntu < healthcheck.patch
+
 # Apache Setup
 RUN cp /var/www/MISP/INSTALL/apache.misp.ubuntu /etc/apache2/sites-available/misp.conf && \
     a2dissite 000-default && \
@@ -177,7 +181,6 @@ RUN sed -i -E 's/^(\s*)system\(\);/\1unix-stream("\/dev\/log");/' /etc/syslog-ng
 # Trigger to perform first boot operations
 ADD run.sh /run.sh
 RUN chmod 0755 /run.sh && touch /.firstboot.tmp
-
 
 # Make a backup of /var/www/MISP to restore it to the local moint point at first boot
 WORKDIR /var/www/MISP

--- a/web/healthcheck.patch
+++ b/web/healthcheck.patch
@@ -1,0 +1,16 @@
+diff --git a/INSTALL/apache.misp.ubuntu b/INSTALL/apache.misp.ubuntu
+index 6581951ea..17ed67982 100644
+--- a/INSTALL/apache.misp.ubuntu
++++ b/INSTALL/apache.misp.ubuntu
+@@ -2,6 +2,11 @@
+     ServerAdmin me@me.local
+     ServerName misp.local
+     DocumentRoot /var/www/MISP/app/webroot
++    <Location "/healthcheck">
++        ErrorDocument 200 "ok"
++        RewriteEngine On
++        RewriteRule "/healthcheck" - [R=200]
++    </Location>
+     <Directory /var/www/MISP/app/webroot>
+         Options -Indexes
+         AllowOverride all


### PR DESCRIPTION
Add an unauthenticated healthcheck endpoint, `/healthcheck` returns status 200, 'ok' payload.

Can be used as a liveness check for containers in Kubernetes.