### PR TITLE
Updated proxy_pass

### DIFF
--- a/proxy/default.conf
+++ b/proxy/default.conf
@@ -15,7 +15,7 @@ server {
 
     location / {
         include /etc/nginx/includes/proxy.conf;
-        proxy_pass http://misp-web;
+        proxy_pass http://misp_web;
     }
 
     access_log off;


### PR DESCRIPTION
proxy_pass was pointing to => http://misp-web whereas the name of the container is set to "misp_web" which we shall change else nginx cant route to the correct path.