### PR TITLE
Fixate to misp-modules 2.4.134

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,3 +50,18 @@ $ docker-compose up
 or
 $ docker-compose -f docker-compose-nginx.yml up
 ```
+
+# Optional NGINX config - SSL certificates
+
+You can create the certificates manually if they are not automatically created.
+
+```
+openssl req -new -nodes -x509 -subj "/C=BE/ST=Brussels/L=Brussels/O=CTI/CN=localhost" -days 3650 -newkey rsa:4096 -keyout proxy/ssl/misp.key -out proxy/ssl/misp.crt
+```
+
+Then rebuild the proxy container and restart al the containers.
+
+```
+docker-compose -f docker-compose-nginx.yml build --no-cache proxy
+docker-compose -f docker-compose-nginx.yml up
+```

--- a/web/Dockerfile
+++ b/web/Dockerfile
@@ -137,7 +137,7 @@ RUN sudo -E apt-get -y install libpoppler73 libpoppler-dev libpoppler-cpp-dev
 
 # Install MISP Modules
 WORKDIR /opt
-RUN git clone https://github.com/MISP/misp-modules.git
+RUN git clone --branch v2.4.134 https://github.com/MISP/misp-modules.git
 RUN cd misp-modules && \
     pip3 install --upgrade pip setuptools wheel && \
     pip3 install scikit-build && \    


### PR DESCRIPTION
Avoid running into https://github.com/MISP/misp-modules/issues/453 ; which blocks deployment of Docker container.