### PR TITLE
Fix bug in patching the MISP.baseurl from environment

### DIFF
--- a/web/run.sh
+++ b/web/run.sh
@@ -100,7 +100,7 @@ if [ -r /.firstboot.tmp ]; then
                 echo "No base URL defined, don't forget to define it manually!"
         else
                 echo "Fixing the MISP base URL ($MISP_BASEURL) ..."
-                sed -i "s/'baseurl' => '',/'baseurl' => '$MISP_BASEURL',/g" /var/www/MISP/app/Config/config.php
+                sed -i "s@'baseurl'[\t ]*=>[\t ]*'',@'baseurl' => '$MISP_BASEURL',@g" /var/www/MISP/app/Config/config.php
         fi
 
         # Generate the admin user PGP key


### PR DESCRIPTION
The web/run.sh script was using a sed command that had two defects, preventing the MISP_BASEURL environment from setting the MISP.baseurl in config.php:
 - pattern used '/' as boundaries, making it incompatible with a baseurl containing that character (supersedes PR #96)
 - pattern assumed 1 space between 'baseurl' and '=>', but the config.php has multiple whitespace/tabs, so broadened the pattern to support any arbitrary length whitespace there

Signed-off-by: Coleman Kane <ckane@colemankane.org>