### PR TITLE
Updates for ubuntu LTS 18.04 -> 20.04

### DIFF
--- a/web/Dockerfile
+++ b/web/Dockerfile
@@ -1,5 +1,5 @@
 
-FROM ubuntu:bionic
+FROM ubuntu:focal
 
 # Install core components
 ENV DEBIAN_FRONTEND noninteractive
@@ -19,7 +19,8 @@ RUN apt-get install -y apache2 apache2-doc apache2-utils && \
     a2dismod status && \
     a2dissite 000-default
 
-# PHP 7.2 and install MySQL PDO extension
+# PHP 7.4 and install MySQL PDO extension
+RUN apt-get update
 RUN apt-get install -y libapache2-mod-php php php-dev php-json \
         php-mysql php-redis php-xml php-mbstring \
         php-gd php-pear php-opcache \
@@ -31,7 +32,7 @@ RUN sed -i \
         -e "s/memory_limit = 128M/memory_limit = 2048M/" \
         -e "s/upload_max_filesize = 2M/upload_max_filesize = 50M/" \
         -e "s/post_max_size = 8M/post_max_size = 50M/" \
-        /etc/php/7.2/apache2/php.ini
+        /etc/php/7.4/apache2/php.ini
 
 RUN apt-get install -y python3-dev python3-pip python3-setuptools \
         python3-lxml libjpeg-dev \
@@ -133,7 +134,7 @@ RUN rm -rf misp-objects && git clone https://github.com/MISP/misp-objects.git &&
     chown -R www-data:www-data misp-objects misp-galaxy warninglists taxonomies
 
 # Install MISP build requirements
-RUN sudo -E apt-get -y install libpoppler73 libpoppler-dev libpoppler-cpp-dev
+RUN sudo -E apt-get -y install libpoppler97 libpoppler-dev libpoppler-cpp-dev
 
 # Install MISP Modules
 WORKDIR /opt

--- a/web/Dockerfile
+++ b/web/Dockerfile
@@ -24,7 +24,8 @@ RUN apt-get update
 RUN apt-get install -y --fix-missing libapache2-mod-php php php-dev php-json \
         php-mysql php-redis php-xml php-mbstring \
         php-gd php-pear php-opcache \
-        pkg-config libbson-1.0 libmongoc-1.0-0
+        pkg-config libbson-1.0 libmongoc-1.0-0 \
+        php-zip php-bcmath php-intl
 
 # Fix php.ini with recommended settings
 RUN sed -i \

--- a/web/Dockerfile
+++ b/web/Dockerfile
@@ -21,7 +21,7 @@ RUN apt-get install -y apache2 apache2-doc apache2-utils && \
 
 # PHP 7.4 and install MySQL PDO extension
 RUN apt-get update
-RUN apt-get install -y libapache2-mod-php php php-dev php-json \
+RUN apt-get install -y --fix-missing libapache2-mod-php php php-dev php-json \
         php-mysql php-redis php-xml php-mbstring \
         php-gd php-pear php-opcache \
         pkg-config libbson-1.0 libmongoc-1.0-0


### PR DESCRIPTION
Apply some updates to bring the Docker image up to Ubuntu 20.04 LTS. Additionally, I took the opportunity to add a few PHP modules that current MISP recommends (intl, zip, bcmath) but weren't in the docker image, and as well made a small error-recovery fix to the apt command line.

This could probably stand to be stress-tested by others, but I just deployed this in a new container with an external existing MISP database, and an external EFS mounted for the "files/" folder, and so far MISP appears to be working fine for me, and the Diagnostics page reflects the software updates I made to the image.

**The key thing here is that "bionic" will be considered EOL later this year, and PHP 7.2 (in bionic) is an older version than what MISP recommends**