### PR TITLE
Fixing typo in template.env

### DIFF
--- a/template.env
+++ b/template.env
@@ -1,4 +1,4 @@
-MYSQL_HOST=misp-db
+MYSQL_HOST=misp_db
 MYSQL_DATABASE=misp
 MYSQL_USER=misp
 MYSQL_PASSWORD=misp


### PR DESCRIPTION
The default name of the database container is set to `misp_db` in docker-compose.yml, yet the MYSQL_HOST it is set to `misp-db` in template.env, which causes misp_web container to constantly wait for the database to start when using template.env as the .env file.