### PR TITLE
Keep correct line endings

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.sh text eol=lf


### PR DESCRIPTION
If you try to build this setup (temporary) on windows the build will propably fail due to the wrong line endings.
By adding the .gitattributes the line endings are fixed to lf. 