### PR TITLE
Update run.sh to include fixing database name in config.php

### DIFF
--- a/web/run.sh
+++ b/web/run.sh
@@ -92,7 +92,8 @@ if [ -r /.firstboot.tmp ]; then
         echo "Creating MISP configuration files"
         cd /var/www/MISP/app/Config
 	cp -a database.default.php database.php
-        sed -i "s/localhost/$MYSQL_HOST/" database.php
+        sed -i "s/'database' => 'misp'/'database' => '$MYSQL_DATABASE'/" database.php
+	sed -i "s/localhost/$MYSQL_HOST/" database.php
         sed -i "s/db\s*login/$MYSQL_USER/" database.php
         sed -i "s/8889/3306/" database.php
         sed -i "s/db\s*password/$MYSQL_PASSWORD/" database.php


### PR DESCRIPTION
If for any reason the name of the database for using misp isn't named "misp", connectivity will fail because database.php does not get updated with the correct name from .env

Ran into this when using a forked version of this project where the web container is run in Docker but MySQL database is running in prod database cluster and required a specific naming convention.

Other parameters in .env are also not updated or translated into database.php