### PR TITLE
Fix template.env MISP_BASEURL default value.

### DIFF
--- a/template.env
+++ b/template.env
@@ -6,7 +6,7 @@ MYSQL_ROOT_PASSWORD=misp
 
 MISP_ADMIN_EMAIL=admin@admin.test
 MISP_ADMIN_PASSPHRASE=admin
-MISP_BASEURL=localhost
+MISP_BASEURL=https://localhost
 
 POSTFIX_RELAY_HOST=relay.fqdn
 TIMEZONE=Europe/Brussels


### PR DESCRIPTION
## Purpose

When use default template.env, cause issue #130.

## What does this PR do?

Change template.env default MISP_BASEURL value to https://localhost .

## Effect

Issue #130 does not occur when using the default template.env.

## Test

This PR was tested in the following environment.
```
No LSB modules are available.
Distributor ID: Ubuntu
Description:    Ubuntu 20.04.4 LTS
Release:        20.04
Codename